### PR TITLE
Added study ownership management controller

### DIFF
--- a/lib/green_light.ex
+++ b/lib/green_light.ex
@@ -69,6 +69,16 @@ defmodule GreenLight do
         |> GreenLight.Ecto.Query.assign_role!(unquote(schema), principal, entity, role)
       end
 
+      def remove_role!(%GreenLight.Principal{} = principal, entity, role) do
+        unquote(repo)
+        |> GreenLight.Ecto.Query.remove_role!(unquote(schema), principal, entity, role)
+      end
+
+      def list_principals(entity) do
+        unquote(repo)
+        |> GreenLight.Ecto.Query.list_principals(unquote(schema), entity)
+      end
+
       @doc """
       Assign a role by piping the result of an Ecto insert operation directly into
       this function.

--- a/lib/green_light/loaders.ex
+++ b/lib/green_light/loaders.ex
@@ -49,7 +49,7 @@ defmodule GreenLight.Loaders do
         @entity_loaders {parent_loader, true}
       end
 
-      @entity_loaders {unquote(loader), false}
+      @entity_loaders {unquote(loader), unquote(Keyword.get(opts, :is_nested, false))}
 
       def load_entities(%Plug.Conn{path_params: path_params} = conn),
         do: unquote(__MODULE__).load_entities(@entity_loaders, conn)

--- a/lib/green_light/plug.ex
+++ b/lib/green_light/plug.ex
@@ -86,5 +86,5 @@ defmodule GreenLight.Plug do
   end
 
   ## User callbacks
-  @callback load_entities(conn :: Plug.Conn.t()) :: {Plug.Conn.t(), list(any())}
+  @callback load_entities(conn :: Plug.Conn.t()) :: {list(any()), Plug.Conn.t()}
 end

--- a/lib/link/authorization.ex
+++ b/lib/link/authorization.ex
@@ -47,6 +47,12 @@ defmodule Link.Authorization do
     delete: [:owner]
   })
 
+  grant_actions(LinkWeb.Studies.PermissionsController, %{
+    show: [:owner],
+    change: [:owner],
+    create: [:owner]
+  })
+
   grant_actions(LinkWeb.ParticipantController, %{
     index: [:owner],
     show: [:owner, :participant],

--- a/lib/link/studies.ex
+++ b/lib/link/studies.ex
@@ -9,6 +9,7 @@ defmodule Link.Studies do
 
   alias Link.Studies.{Study, Participant}
   alias Link.Users.User
+  alias GreenLight.Principal
 
   @doc """
   Returns the list of studies.
@@ -40,6 +41,44 @@ defmodule Link.Studies do
       )
 
     from(s in Study, where: s.id in subquery(entity_ids)) |> Repo.all()
+  end
+
+  def list_owners(%Study{} = study) do
+    owner_ids =
+      study
+      |> Authorization.list_principals()
+      |> Enum.filter(fn %{roles: roles} -> MapSet.member?(roles, :owner) end)
+      |> Enum.map(fn %{id: id} -> id end)
+
+    from(u in User, where: u.id in ^owner_ids, order_by: u.id) |> Repo.all()
+  end
+
+  def assign_owners(study, users) do
+    existing_owner_ids =
+      Authorization.list_principals(study)
+      |> Enum.filter(fn %{roles: roles} -> MapSet.member?(roles, :owner) end)
+      |> Enum.map(fn %{id: id} -> id end)
+      |> Enum.into(MapSet.new())
+
+    new_owners = users |> Enum.map(&Authorization.principal/1)
+
+    new_owners
+    |> Enum.filter(fn principal -> not MapSet.member?(existing_owner_ids, principal.id) end)
+    |> Enum.each(&Authorization.assign_role!(&1, study, :owner))
+
+    new_owner_ids =
+      new_owners
+      |> Enum.map(fn %{id: id} -> id end)
+      |> Enum.into(MapSet.new())
+
+    existing_owner_ids
+    |> Enum.filter(fn id -> not MapSet.member?(new_owner_ids, id) end)
+    |> Enum.each(&Authorization.remove_role!(%Principal{id: &1}, study, :owner))
+  end
+
+  def add_owner!(study, user) do
+    user
+    |> Authorization.assign_role!(study, :owner)
   end
 
   @doc """

--- a/lib/link_web/controllers/study/permissions_controller.ex
+++ b/lib/link_web/controllers/study/permissions_controller.ex
@@ -1,0 +1,44 @@
+defmodule LinkWeb.Studies.PermissionsController do
+  use LinkWeb, :controller
+  alias Link.{Studies, Users}
+
+  entity_loader(&LinkWeb.Loaders.study!/3, is_nested: true)
+
+  def show(%{assigns: %{study: study}} = conn, _params) do
+    owners = Studies.list_owners(study)
+    render(conn, "show.html", owners: owners)
+  end
+
+  def change(%{assigns: %{study: study}} = conn, %{"owners" => selected_owners}) do
+    owners_to_delete =
+      selected_owners
+      |> Enum.map(&String.to_integer/1)
+      |> MapSet.new()
+
+    owners =
+      Studies.list_owners(study)
+      |> Enum.reject(fn owner -> MapSet.member?(owners_to_delete, owner.id) end)
+
+    :ok = Studies.assign_owners(study, owners)
+
+    conn
+    |> put_flash(:info, "Removed owners.")
+    |> redirect(to: Routes.study_permissions_path(conn, :show, study))
+  end
+
+  def create(%{assigns: %{study: study}} = conn, %{"email" => email}) do
+    case Users.get_by(email: email) do
+      nil ->
+        conn
+        |> put_flash(:error, "User with #{email} does not exist.")
+        |> show(%{})
+
+      user ->
+        Studies.add_owner!(study, user)
+
+        conn
+        |> put_flash(:info, "Added owner: #{email}.")
+        |> redirect(to: Routes.study_permissions_path(conn, :show, study))
+    end
+  end
+end

--- a/lib/link_web/router.ex
+++ b/lib/link_web/router.ex
@@ -83,6 +83,9 @@ defmodule LinkWeb.Router do
 
     resources "/studies", StudyController do
       resources "/survey-tools", SurveyToolController
+      get "/permissions", Studies.PermissionsController, :show
+      patch "/permissions", Studies.PermissionsController, :change
+      post "/permissions", Studies.PermissionsController, :create
     end
 
     get "/studies/:id/participate", ParticipantController, :new

--- a/lib/link_web/templates/studies/permissions/show.html.eex
+++ b/lib/link_web/templates/studies/permissions/show.html.eex
@@ -1,0 +1,21 @@
+<div class="ml-8 mr-8">
+  <h1 class="text-title5 sm:text-title2 lg:text-title1 font-black mt-8 mb-4">Permissions</h1>
+  <div class="mb-4">
+    <%= form_for @conn, Routes.study_permissions_path(@conn, :create, @study), fn f -> %>
+    <%= label f, :email, "E-mail:" %>
+    <%= text_input f, :email, class: "border ml-2 mr-2" %>
+    <%= submit "Add Owner", class: "p-1 pl-4 pr-4 bg-warning text-white"  %>
+  <% end %>
+</div>
+<%= form_for @conn, Routes.study_permissions_path(@conn, :change, @study), [method: :patch], fn f -> %>
+<table>
+  <%= for owner <- @owners do %>
+    <tr>
+      <td class="p-2"><%= checkbox f, "owners[]", checked_value: owner.id, hidden_input: false, disabled: owner.id == @current_user.id %></td>
+      <td><%= owner.email %></td>
+    </tr>
+  <% end %>
+</table>
+<%= submit "Delete", class: "p-1 pl-4 pr-4 bg-warning text-white"  %>
+<% end %>
+</div>

--- a/lib/link_web/views/studies/permissions_view.ex
+++ b/lib/link_web/views/studies/permissions_view.ex
@@ -1,0 +1,3 @@
+defmodule LinkWeb.Studies.PermissionsView do
+  use LinkWeb, :view
+end

--- a/test/link/studies_test.exs
+++ b/test/link/studies_test.exs
@@ -139,5 +139,38 @@ defmodule Link.StudiesTest do
       Studies.apply_participant(study, member)
       assert Studies.list_participations(member) == [study]
     end
+
+    test "add_owner!/2 grants a user ownership over a study" do
+      researcher_1 = Factories.get_or_create_researcher()
+      researcher_2 = Factories.get_or_create_researcher()
+      study = Factories.create_study(owner: researcher_1)
+      # The second researcher is not the owner of the study
+      assert Studies.list_owned_studies(researcher_2) == []
+      Studies.add_owner!(study, researcher_2)
+      # The second researcher is now an owner of the study
+      assert Studies.list_owned_studies(researcher_2) == [study]
+    end
+
+    test "assign_owners/2 adds or removes a users ownership of a study" do
+      researcher_1 = Factories.get_or_create_researcher()
+      researcher_2 = Factories.get_or_create_researcher()
+      study = Factories.create_study(owner: researcher_1)
+      # The second researcher is not the owner of the study
+      assert Studies.list_owned_studies(researcher_2) == []
+      Studies.assign_owners(study, [researcher_2])
+      # The second researcher is now an owner of the study
+      assert Studies.list_owned_studies(researcher_2) == [study]
+      # The original owner can no longer claim ownership
+      assert Studies.list_owned_studies(researcher_1) == []
+    end
+
+    test "list_owners/1 returns all users with ownership permission on the study" do
+      researcher_1 = Factories.get_or_create_researcher()
+      researcher_2 = Factories.get_or_create_researcher()
+      study = Factories.create_study(owner: researcher_1)
+      assert Studies.list_owners(study) == [researcher_1]
+      Studies.assign_owners(study, [researcher_2])
+      assert Studies.list_owners(study) == [researcher_2]
+    end
   end
 end

--- a/test/link_web/controllers/studies/permissions_controller_test.exs
+++ b/test/link_web/controllers/studies/permissions_controller_test.exs
@@ -1,0 +1,68 @@
+defmodule LinkWeb.Studies.PermissionsControllerTest do
+  use LinkWeb.ConnCase
+
+  alias Link.{Studies, Factories}
+
+  setup %{conn: conn} do
+    user = Factories.get_or_create_researcher()
+    study = Factories.create_study(owner: user)
+    conn = Pow.Plug.assign_current_user(conn, user, otp_app: :link_web)
+
+    {:ok, conn: conn, user: user, study: study}
+  end
+
+  describe "add owner" do
+    test "can add user as an owner", %{conn: conn, study: study} do
+      additional_user = Factories.get_or_create_researcher()
+
+      update_conn =
+        post(conn, Routes.study_permissions_path(conn, :create, study),
+          email: additional_user.email
+        )
+
+      assert redirected_to(update_conn) ==
+               Routes.study_permissions_path(update_conn, :show, study)
+
+      conn = get(conn, Routes.study_permissions_path(conn, :show, study))
+      assert html_response(conn, 200) =~ additional_user.email
+    end
+
+    test "adding an owner keeps the orignal owners", %{conn: conn, study: study, user: user} do
+      current_owners = [user, Factories.get_or_create_researcher()]
+      Studies.assign_owners(study, current_owners)
+
+      additional_user = Factories.get_or_create_researcher()
+
+      post(conn, Routes.study_permissions_path(conn, :create, study), email: additional_user.email)
+
+      assert Studies.list_owners(study) == current_owners ++ [additional_user]
+    end
+
+    test "reports error when adding non-existing user", %{conn: conn, study: study} do
+      conn =
+        post(conn, Routes.study_permissions_path(conn, :create, study),
+          email: Faker.Internet.email()
+        )
+
+      assert html_response(conn, 200) =~ "does not exist"
+    end
+  end
+
+  describe "remove owner" do
+    test "can remove an owner from a study", %{conn: conn, study: study, user: user} do
+      additional_user = Factories.get_or_create_researcher()
+      Studies.assign_owners(study, [additional_user, user])
+
+      update_conn =
+        patch(conn, Routes.study_permissions_path(conn, :change, study),
+          owners: [additional_user.id |> to_string()]
+        )
+
+      assert redirected_to(update_conn) ==
+               Routes.study_permissions_path(update_conn, :show, study)
+
+      conn = get(conn, Routes.study_permissions_path(conn, :show, study))
+      refute html_response(conn, 200) =~ additional_user.email
+    end
+  end
+end


### PR DESCRIPTION
To access the controller add /permissions to a study show screen (/studies/X/permissions). This controller is not yet linked from the interface on purpose since there might not be enough time to make it nice before the demo.